### PR TITLE
Extract refactor

### DIFF
--- a/disco/infer.py
+++ b/disco/infer.py
@@ -184,7 +184,8 @@ def run_inference(
         infer.pickle_tensor(votes, votes_path)
 
     if accuracy_metrics:
-        default_dirname = "test_files" + "-" + os.path.split(os.path.split(saved_model_directory)[0])[-1]
+
+        default_dirname = f"test_files-{os.path.basename(saved_model_directory)}"
         metrics_path = os.path.join("data", "accuracy_metrics", default_dirname)
         os.makedirs(metrics_path, exist_ok=True)
 

--- a/disco/resources/extract_runner.sh
+++ b/disco/resources/extract_runner.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+data_dir="/home/tc229954/extracted_data_1150_nffts"
+#
+echo "Running extraction."
+# shellcheck disable=SC2162
+find /mnt/beegfs/tc229954/beetles_data/ -name "*.csv" | grep -v predictions | grep -v debug | while read file;
+do
+  wav="${file%%.*}".wav
+  disco extract --mel_scale "$file" "$wav" $data_dir
+done
+
+echo "PLEASE VISUALLY CHECK ALL EXTRACTED DATA."
+echo "Running shuffle."
+disco shuffle "$data_dir"
+# shellcheck disable=SC2012
+train_num=$(ls "$data_dir"/train | wc -l)
+# shellcheck disable=SC2012
+test_num=$(ls "$data_dir"/test | wc -l)
+# shellcheck disable=SC2012
+validation_num=$(ls "$data_dir"/validation | wc -l)
+echo "num. train files: $train_num"
+echo "num. test files: $test_num"
+echo "num. validation files: $validation_num"
+#
+echo "Running train."
+# data_dir=$HOME/data/beetles/extracted_data/mel_no_log_1150_no_vert_trim/
+
+for method in random_init bootstrap;
+do
+for members in 2 10 30;
+  do
+  # shellcheck disable=SC2004
+  for ((i = 0 ; i < $members ; i++ ))
+    do
+      echo "training model $i with method $method $members"
+      bash disco/train.sh "trained_models_beetle_sept9/ensemble_""$members"_"$method" $method "$data_dir"
+    done
+  done
+done
+
+for method in random_init bootstrap;
+do
+  for members in 2 10 30;
+    do
+        bash disco/infer.sh "$data_dir"/test "trained_models_beetle/ensemble_""$members"_"$method"
+    done
+done
+# THEN COMPUTE ACCURACY.
+# PRINTS OUT the stuff
+python3 disco/accuracy_metrics.py 2 "random_init"
+python3 disco/accuracy_metrics.py 2 "bootstrap"
+
+python3 disco/accuracy_metrics.py 10 "random_init"
+python3 disco/accuracy_metrics.py 10 "bootstrap"
+
+python3 disco/accuracy_metrics.py 30 "random_init"
+python3 disco/accuracy_metrics.py 30 "bootstrap"
+
+
+

--- a/disco/train.py
+++ b/disco/train.py
@@ -123,11 +123,9 @@ def train(config, hparams):
         "max_epochs": last_epoch + (max_iter * min_training_unit),
         "check_val_every_n_epoch": hparams.check_val_every_n_epoch,
         "callbacks": [checkpoint_callback, lr_monitor],
-        "accelerator": "ddp" if hparams.gpus else None,
-        "plugins": DDPPlugin(find_unused_parameters=False) if hparams.gpus else None,
         "precision": 16 if hparams.gpus else 32,
         "log_every_n_steps": 1,
-        "terminate_on_nan": True,
+        "detect_anomaly": True,
         "logger": logger,
     }
 


### PR DESCRIPTION
Overhaul the extraction pipeline. Now users extract data from a single file. Data is then shuffled and split into train/test/val with a separate command, `disco shuffle`. This will really increase usability. In addition, write csv exporters for accuracy metrics and add some cuda/cpu type checking into the inference pipeline.